### PR TITLE
 add support for --no-coverage option to just run unit tests with mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,17 @@ jenkins-mocha should replace your mocha command in npm test
 }
 ```
 
-Any parameters added to the command will be passed directly to mocha.
+If you want to turn off coverage reporting and just run unit tests with mocha, you need to pass a `--no-coverage` option to the command
+
+```json
+{
+    "scripts": {
+        "devtest": "jenkins-mocha --no-coverage test/*"
+    }
+}
+```
+
+Any other parameters added to the command will be passed directly to mocha.
 
 When npm-test is invoked, the module will:
  - Create XUnit test results in `$(TEST_DIR)`

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -45,10 +45,22 @@ module.exports = function (args) {
         args.unshift('--colors');
     }
 
+    var command = [];
+
+    var noCoverageIndex = args.indexOf('--no-coverage');
+    if (noCoverageIndex === -1) {
+        // we want coverage
+        command.push(getBin('istanbul') + ' cover --dir ' + directories.coverage + ' --');
+        command.push(getBin('_mocha'));
+    } else {
+        // remove the --no-coverage option from args array
+        args.splice(noCoverageIndex, 1);
+        command.push(getBin('mocha'));
+    }
+
+    command.push('--reporter ' + path.resolve(directories.base, 'spec-xunit-file'));
+    command.push(args.join(' '));
+
     // Trigger istanbul and mocha
-    shell.exit(shell.exec(
-        getBin('istanbul') + ' cover --dir ' + directories.coverage + ' -- ' +
-        getBin('_mocha') + ' --reporter ' + path.resolve(directories.base, 'spec-xunit-file') + ' ' +
-        args.join(' ')
-    ).code);
+    shell.exit(shell.exec(command.join(' ')).code);
 };


### PR DESCRIPTION
@stjohnjohnson 

resolves #4 
includes unit test + doc update
