### PR TITLE
support npm@3

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -31,7 +31,6 @@ module.exports = function (args) {
     directories.artifacts = shell.env.ARTIFACTS_DIR || path.join(process.cwd(), 'artifacts');
     directories.coverage = shell.env.COVERAGE_DIR || path.join(directories.artifacts, 'coverage');
     directories.tests = shell.env.TEST_DIR || path.join(directories.artifacts, 'test');
-    directories.base = path.join(__dirname, '..', 'node_modules');
 
     // Make sure directories exist
     Object.keys(directories).forEach(function (name) {
@@ -58,7 +57,7 @@ module.exports = function (args) {
         command.push(getBin('mocha'));
     }
 
-    command.push('--reporter ' + path.resolve(directories.base, 'spec-xunit-file'));
+    command.push('--reporter ' + require.resolve('spec-xunit-file'));
     command.push(args.join(' '));
 
     // Trigger istanbul and mocha

--- a/test/jenkins.test.js
+++ b/test/jenkins.test.js
@@ -14,7 +14,7 @@ var A = require('chai').assert,
     },
     node_modules = path.join(__dirname, '..', 'node_modules'),
     istanbulPath = path.join(node_modules, '.bin', 'istanbul'),
-    specXunitPath = path.join(node_modules, 'spec-xunit-file'),
+    specXunitPath = require.resolve('spec-xunit-file'),
     mochaPath = path.join(node_modules, '.bin', 'mocha'),
     _mochaPath = path.join(node_modules, '.bin', '_mocha');
 


### PR DESCRIPTION
The issue arises due to npm@3's more agressive tendency towards "flat
dependencies". This leaves the reporter dependency in a location that
jenkins-mocha isn't expecting, when jenkins-mocha is installed into a
parent project. The solution here is to use require.resolve in order to
figure out where the reporter dependency ought to be found.
