### PR TITLE
support a --cobertura option for istanbul

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,19 @@ jenkins-mocha should replace your mocha command in npm test
 }
 ```
 
-If you want to turn off coverage reporting and just run unit tests with mocha, you need to pass a `--no-coverage` option to the command
+With coverage on (the default), you can pass a `--cobertura` option to the command
+to have istanbul use the cobertura reporter
+  
+```json
+{
+    "scripts": {
+        "devtest": "jenkins-mocha --cobertura test/*"
+    }
+}
+```
+
+If you want to turn coverage reporting off entirely, and just run unit tests with mocha, 
+you need to pass a `--no-coverage` option to the command
 
 ```json
 {

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -50,6 +50,7 @@ module.exports = function (args) {
     if (noCoverageIndex === -1) {
         // we want coverage
         command.push(getBin('istanbul'));
+        command.push('cover');
 
         // .. but do we want cobertura?
         var coberturaIndex = args.indexOf('--cobertura');
@@ -59,7 +60,7 @@ module.exports = function (args) {
             command.push('--report cobertura');
         }
 
-        command.push('cover --dir ' + directories.coverage + ' --');
+        command.push('--dir ' + directories.coverage + ' --');
         command.push(getBin('_mocha'));
     } else {
         // remove the --no-coverage option from args array

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -49,7 +49,17 @@ module.exports = function (args) {
     var noCoverageIndex = args.indexOf('--no-coverage');
     if (noCoverageIndex === -1) {
         // we want coverage
-        command.push(getBin('istanbul') + ' cover --dir ' + directories.coverage + ' --');
+        command.push(getBin('istanbul'));
+
+        // .. but do we want cobertura?
+        var coberturaIndex = args.indexOf('--cobertura');
+        if (coberturaIndex !== -1) {
+            // remove the --cobertura option from args array
+            args.splice(coberturaIndex, 1);
+            command.push('--report cobertura');
+        }
+
+        command.push('cover --dir ' + directories.coverage + ' --');
         command.push(getBin('_mocha'));
     } else {
         // remove the --no-coverage option from args array

--- a/test/jenkins.test.js
+++ b/test/jenkins.test.js
@@ -120,5 +120,31 @@ describe('Jenkins Mocha Test Case', function () {
                 mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo tests/*'
             ], 'mocha was called correctly');
         });
+
+        it('should support a --cobertura option', function () {
+            mocks.exec.returns({
+                code: 0
+            });
+
+            // Run
+            require('../lib/jenkins')(['--foo', 'tests/*', '--cobertura']);
+
+            // Check mkdirs
+            A.equalObject(mocks.mkdir.args[0], ['-p', path.join(process.cwd(), 'artifacts')], 'artifact dir was created');
+            A.equalObject(mocks.mkdir.args[1], ['-p', path.join(process.cwd(), 'artifacts', 'coverage')], 'coverage dir was created');
+            A.equalObject(mocks.mkdir.args[2], ['-p', path.join(process.cwd(), 'artifacts', 'test')], 'tests dir was created');
+
+            // Check environment
+            A.equalObject(mocks.env, {
+                XUNIT_FILE: path.join(process.cwd(), 'artifacts', 'test', 'xunit.xml')
+            }, 'xunit file was set');
+
+            // Check exec
+            A.equalObject(mocks.exec.args[0], [
+                istanbulPath + ' --report cobertura cover --dir ' +
+                path.join(process.cwd(), 'artifacts', 'coverage') +
+                ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo tests/*'
+            ], 'mocha was called correctly');
+        });
     });
 });

--- a/test/jenkins.test.js
+++ b/test/jenkins.test.js
@@ -141,7 +141,7 @@ describe('Jenkins Mocha Test Case', function () {
 
             // Check exec
             A.equalObject(mocks.exec.args[0], [
-                istanbulPath + ' --report cobertura cover --dir ' +
+                istanbulPath + ' cover --report cobertura --dir ' +
                 path.join(process.cwd(), 'artifacts', 'coverage') +
                 ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo tests/*'
             ], 'mocha was called correctly');


### PR DESCRIPTION
.. this method of adding options isn't going to be scalable for long, but I figured since the --no-coverage option made it in, this might.  I need cobertura support for my jenkins installation.  
