### PR TITLE
Space in directory names-fix

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -80,7 +80,7 @@ module.exports = function (args) {
     }
 
     command.push('--reporter ' + escape(require.resolve('spec-xunit-file')));
-    command.push(args.join(' '));
+    command.push(shellescape(args));
 
     // Trigger istanbul and mocha
     shell.exit(shell.exec(command.join(' ')).code);

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -2,6 +2,7 @@
 
 /*global __dirname, process, require, module */
 var shell = require('shelljs'),
+    shellescape = require('shell-escape'),
     path = require('path'),
     whichLocal = require('npm-which')(path.resolve(__dirname, '..')),
     whichCwd = require('npm-which')(process.cwd()),
@@ -17,10 +18,20 @@ shell.config.fatal = true;
  */
 function getBin(filename) {
     try {
-        return whichLocal.sync(filename);
+        return escape(whichLocal.sync(filename));
     } catch (unused) {
-        return whichCwd.sync(filename);
+        return escape(whichCwd.sync(filename));
     }
+}
+
+/**
+ * Escapes directory path, single argument version for 'shell-escape'.
+ * @method escape
+ * @param  {string} directory Directory you wish to escape
+ * @return {string}          Escaped directory
+ */
+function escape(directory){
+    return shellescape([directory]);
 }
 
 /**
@@ -34,7 +45,7 @@ module.exports = function (args) {
 
     // Make sure directories exist
     Object.keys(directories).forEach(function (name) {
-        shell.mkdir('-p', directories[name]);
+        shell.mkdir('-p', escape(directories[name]));
     });
 
     // Set Xunit file
@@ -60,7 +71,7 @@ module.exports = function (args) {
             command.push('--report cobertura');
         }
 
-        command.push('--dir ' + directories.coverage + ' --');
+        command.push('--dir ' + escape(directories.coverage) + ' --');
         command.push(getBin('_mocha'));
     } else {
         // remove the --no-coverage option from args array
@@ -68,7 +79,7 @@ module.exports = function (args) {
         command.push(getBin('mocha'));
     }
 
-    command.push('--reporter ' + require.resolve('spec-xunit-file'));
+    command.push('--reporter ' + escape(require.resolve('spec-xunit-file')));
     command.push(args.join(' '));
 
     // Trigger istanbul and mocha

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -45,7 +45,7 @@ module.exports = function (args) {
 
     // Make sure directories exist
     Object.keys(directories).forEach(function (name) {
-        shell.mkdir('-p', escape(directories[name]));
+        shell.mkdir('-p', directories[name]);
     });
 
     // Set Xunit file

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "mocha": "^2.1.0",
     "npm-which": "^2.0.0",
     "shelljs": "^0.3.0",
-    "spec-xunit-file": "0.0.1-3"
+    "spec-xunit-file": "0.0.1-3",
+    "shell-escape": "^0.2.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/test/jenkins.test.js
+++ b/test/jenkins.test.js
@@ -78,7 +78,7 @@ describe('Jenkins Mocha Test Case', function () {
             A.equalObject(mocks.exec.args[0], [
                 istanbulPath + ' cover --dir ' +
                 coverage +
-                ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo tests/*'
+                ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo \'tests/*\''
             ], 'mocha was called correctly');
         });
 
@@ -101,7 +101,7 @@ describe('Jenkins Mocha Test Case', function () {
             A.equalObject(mocks.exec.args[0], [
                 istanbulPath + ' cover --dir ' +
                 coverage +
-                ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --foo tests/* --no-colors'
+                ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --foo \'tests/*\' --no-colors'
             ], 'mocha was called correctly');
         });
 
@@ -122,7 +122,7 @@ describe('Jenkins Mocha Test Case', function () {
 
             // Check exec
             A.equalObject(mocks.exec.args[0], [
-                mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo tests/*'
+                mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo \'tests/*\''
             ], 'mocha was called correctly');
         });
 
@@ -145,7 +145,7 @@ describe('Jenkins Mocha Test Case', function () {
             A.equalObject(mocks.exec.args[0], [
                 istanbulPath + ' cover --report cobertura --dir ' +
                 coverage +
-                ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo tests/*'
+                ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo \'tests/*\''
             ], 'mocha was called correctly');
         });
     });

--- a/test/jenkins.test.js
+++ b/test/jenkins.test.js
@@ -5,6 +5,7 @@ var A = require('chai').assert,
     mockery = require('mockery'),
     sinon = require('sinon'),
     path = require('path'),
+    shellescape = require('shell-escape'),
     mocks = {
         mkdir: sinon.stub(),
         exec: sinon.stub(),
@@ -13,14 +14,20 @@ var A = require('chai').assert,
         env: {}
     },
     node_modules = path.join(__dirname, '..', 'node_modules'),
-    istanbulPath = path.join(node_modules, '.bin', 'istanbul'),
-    specXunitPath = require.resolve('spec-xunit-file'),
-    mochaPath = path.join(node_modules, '.bin', 'mocha'),
-    _mochaPath = path.join(node_modules, '.bin', '_mocha');
+    istanbulPath = escape(path.join(node_modules, '.bin', 'istanbul')),
+    specXunitPath = escape(require.resolve('spec-xunit-file')),
+    mochaPath = escape(path.join(node_modules, '.bin', 'mocha')),
+    _mochaPath = escape(path.join(node_modules, '.bin', '_mocha')),
+    coverage = escape(path.join(process.cwd(), 'artifacts', 'coverage'));
+
 
 A.equalObject = function (a, b, message) {
     A.equal(JSON.stringify(a, null, 4), JSON.stringify(b, null, 4), message);
 };
+
+function escape(directory){
+    return shellescape([directory]);
+}
 
 describe('Jenkins Mocha Test Case', function () {
     beforeEach(function () {
@@ -44,6 +51,13 @@ describe('Jenkins Mocha Test Case', function () {
         mockery.disable();
     });
 
+    function assertMkDirCallsAreReceived(){
+        // Check mkdirs
+        A.equalObject(mocks.mkdir.args[0], ['-p', escape(path.join(process.cwd(), 'artifacts'))], 'artifact dir was created');
+        A.equalObject(mocks.mkdir.args[1], ['-p', escape(path.join(process.cwd(), 'artifacts', 'coverage'))], 'coverage dir was created');
+        A.equalObject(mocks.mkdir.args[2], ['-p', escape(path.join(process.cwd(), 'artifacts', 'test'))], 'tests dir was created');
+    }
+
     describe('jenkins', function () {
         it('should run the right functions', function () {
             mocks.exec.returns({
@@ -53,10 +67,7 @@ describe('Jenkins Mocha Test Case', function () {
             // Run
             require('../lib/jenkins')(['--foo', 'tests/*']);
 
-            // Check mkdirs
-            A.equalObject(mocks.mkdir.args[0], ['-p', path.join(process.cwd(), 'artifacts')], 'artifact dir was created');
-            A.equalObject(mocks.mkdir.args[1], ['-p', path.join(process.cwd(), 'artifacts', 'coverage')], 'coverage dir was created');
-            A.equalObject(mocks.mkdir.args[2], ['-p', path.join(process.cwd(), 'artifacts', 'test')], 'tests dir was created');
+            assertMkDirCallsAreReceived();
 
             // Check environment
             A.equalObject(mocks.env, {
@@ -66,7 +77,7 @@ describe('Jenkins Mocha Test Case', function () {
             // Check exec
             A.equalObject(mocks.exec.args[0], [
                 istanbulPath + ' cover --dir ' +
-                path.join(process.cwd(), 'artifacts', 'coverage') +
+                coverage +
                 ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo tests/*'
             ], 'mocha was called correctly');
         });
@@ -79,10 +90,7 @@ describe('Jenkins Mocha Test Case', function () {
             // Run
             require('../lib/jenkins')(['--foo', 'tests/*', '--no-colors']);
 
-            // Check mkdirs
-            A.equalObject(mocks.mkdir.args[0], ['-p', path.join(process.cwd(), 'artifacts')], 'artifact dir was created');
-            A.equalObject(mocks.mkdir.args[1], ['-p', path.join(process.cwd(), 'artifacts', 'coverage')], 'coverage dir was created');
-            A.equalObject(mocks.mkdir.args[2], ['-p', path.join(process.cwd(), 'artifacts', 'test')], 'tests dir was created');
+            assertMkDirCallsAreReceived();
 
             // Check environment
             A.equalObject(mocks.env, {
@@ -92,7 +100,7 @@ describe('Jenkins Mocha Test Case', function () {
             // Check exec
             A.equalObject(mocks.exec.args[0], [
                 istanbulPath + ' cover --dir ' +
-                path.join(process.cwd(), 'artifacts', 'coverage') +
+                coverage +
                 ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --foo tests/* --no-colors'
             ], 'mocha was called correctly');
         });
@@ -105,10 +113,7 @@ describe('Jenkins Mocha Test Case', function () {
             // Run
             require('../lib/jenkins')(['--foo', 'tests/*', '--no-coverage']);
 
-            // Check mkdirs
-            A.equalObject(mocks.mkdir.args[0], ['-p', path.join(process.cwd(), 'artifacts')], 'artifact dir was created');
-            A.equalObject(mocks.mkdir.args[1], ['-p', path.join(process.cwd(), 'artifacts', 'coverage')], 'coverage dir was not created');
-            A.equalObject(mocks.mkdir.args[2], ['-p', path.join(process.cwd(), 'artifacts', 'test')], 'tests dir was created');
+            assertMkDirCallsAreReceived();
 
             // Check environment
             A.equalObject(mocks.env, {
@@ -129,10 +134,7 @@ describe('Jenkins Mocha Test Case', function () {
             // Run
             require('../lib/jenkins')(['--foo', 'tests/*', '--cobertura']);
 
-            // Check mkdirs
-            A.equalObject(mocks.mkdir.args[0], ['-p', path.join(process.cwd(), 'artifacts')], 'artifact dir was created');
-            A.equalObject(mocks.mkdir.args[1], ['-p', path.join(process.cwd(), 'artifacts', 'coverage')], 'coverage dir was created');
-            A.equalObject(mocks.mkdir.args[2], ['-p', path.join(process.cwd(), 'artifacts', 'test')], 'tests dir was created');
+            assertMkDirCallsAreReceived();
 
             // Check environment
             A.equalObject(mocks.env, {
@@ -142,7 +144,7 @@ describe('Jenkins Mocha Test Case', function () {
             // Check exec
             A.equalObject(mocks.exec.args[0], [
                 istanbulPath + ' cover --report cobertura --dir ' +
-                path.join(process.cwd(), 'artifacts', 'coverage') +
+                coverage +
                 ' -- ' + _mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo tests/*'
             ], 'mocha was called correctly');
         });

--- a/test/jenkins.test.js
+++ b/test/jenkins.test.js
@@ -53,9 +53,9 @@ describe('Jenkins Mocha Test Case', function () {
 
     function assertMkDirCallsAreReceived(){
         // Check mkdirs
-        A.equalObject(mocks.mkdir.args[0], ['-p', escape(path.join(process.cwd(), 'artifacts'))], 'artifact dir was created');
-        A.equalObject(mocks.mkdir.args[1], ['-p', escape(path.join(process.cwd(), 'artifacts', 'coverage'))], 'coverage dir was created');
-        A.equalObject(mocks.mkdir.args[2], ['-p', escape(path.join(process.cwd(), 'artifacts', 'test'))], 'tests dir was created');
+        A.equalObject(mocks.mkdir.args[0], ['-p', path.join(process.cwd(), 'artifacts')], 'artifact dir was created');
+        A.equalObject(mocks.mkdir.args[1], ['-p', path.join(process.cwd(), 'artifacts', 'coverage')], 'coverage dir was created');
+        A.equalObject(mocks.mkdir.args[2], ['-p', path.join(process.cwd(), 'artifacts', 'test')], 'tests dir was created');
     }
 
     describe('jenkins', function () {


### PR DESCRIPTION
Hopefully this fixes the problem with the spaces in the directory names (Issue #10) 
Notes: mkdir was fine with spaces, it didn't like quotes.
