### PR TITLE
Peer up those dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "bugs": "https://github.com/stjohnjohnson/jenkins-mocha/issues",
   "license": "MIT",
   "peerDependencies": {
-    "istanbul": "^0.4.0",
+    "istanbul": ">0.4.0",
     "mocha": "^3.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
   },
   "bugs": "https://github.com/stjohnjohnson/jenkins-mocha/issues",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "istanbul": "^0.4.0",
-    "mocha": "^3.0.0",
+    "mocha": "^3.0.0"
+  },
+  "dependencies": {
     "npm-which": "^3.0.0",
     "shelljs": "^0.7.3",
     "spec-xunit-file": "0.0.1-3",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "bugs": "https://github.com/stjohnjohnson/jenkins-mocha/issues",
   "license": "MIT",
   "peerDependencies": {
-    "istanbul": ">0.4.0",
-    "mocha": "^3.0.0"
+    "istanbul": "*",
+    "mocha": "*"
   },
   "dependencies": {
     "npm-which": "^3.0.0",


### PR DESCRIPTION
I use istanbul 1.1.0-alpha.1 which allows me to use es6 syntax and plugins n stuff

Switching the requirements to peer lets me use your util, but the newer tools