### PR TITLE
Include a text summary in the default report

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -70,7 +70,7 @@ module.exports = function (args) {
             args.splice(coberturaIndex, 1);
             command.push('--reporter cobertura');
         } else {
-            command.push('--reporter lcov');
+            command.push('--reporter lcov --reporter text-summary');
         }
 
         command.push('--report-dir ' + escape(directories.coverage) + ' --');

--- a/test/jenkins.test.js
+++ b/test/jenkins.test.js
@@ -79,7 +79,7 @@ describe('Jenkins Mocha Test Case', function () {
 
             // Check exec
             A.equalObject(mocks.exec.args[0], [
-                'node  ' + nycPath + ' --reporter lcov --report-dir ' +
+                'node  ' + nycPath + ' --reporter lcov --reporter text-summary --report-dir ' +
                 coverage +
                 ' -- node  ' + _mochaPath + ' --reporter ' + specXunitPath + ' --colors --foo \'tests/*\''
             ], 'mocha was called correctly');
@@ -102,7 +102,7 @@ describe('Jenkins Mocha Test Case', function () {
 
             // Check exec
             A.equalObject(mocks.exec.args[0], [
-                'node  ' + nycPath + ' --reporter lcov --report-dir ' +
+                'node  ' + nycPath + ' --reporter lcov --reporter text-summary --report-dir ' +
                 coverage +
                 ' -- node  ' + _mochaPath + ' --reporter ' + specXunitPath + ' --foo \'tests/*\' --no-colors'
             ], 'mocha was called correctly');
@@ -171,7 +171,7 @@ describe('Jenkins Mocha Test Case', function () {
 
             // Check exec
             A.equalObject(mocks.exec.args[0], [
-                'node --flop=blop ' + nycPath + ' --reporter lcov --report-dir ' +
+                'node --flop=blop ' + nycPath + ' --reporter lcov --reporter text-summary --report-dir ' +
                 coverage +
                 ' -- node --flop=blop ' + _mochaPath + ' --reporter ' + specXunitPath + ' --foo \'tests/*\' --no-colors'
             ], 'mocha was called correctly');


### PR DESCRIPTION
@stjohnjohnson as discussed, pre-4.x versions of `jenkins-mocha` that did not use `nyc` would output `lcov` as well as `text-summary` by default. In `nyc`, one must specify multiple reporters to restore this default behavior.