### PR TITLE
Upgrade to nyc@11

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "mocha": "^3.0.0",
     "npm-which": "^3.0.0",
-    "nyc": "^10.0.0",
+    "nyc": "^11.0.0",
     "shell-escape": "^0.2.0",
     "shelljs": "^0.7.5",
     "spec-xunit-file": "0.0.1-3"


### PR DESCRIPTION
@stjohnjohnson @petey 

Only major breaking change is upgrading find-up which removed support for Node 0.10 and 0.12.