### PR TITLE
[major] Bump NYC and Mocha to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "bugs": "https://github.com/stjohnjohnson/jenkins-mocha/issues",
   "license": "MIT",
   "dependencies": {
-    "mocha": "^6.0.0",
+    "mocha": "^7.1.1",
     "npm-which": "^3.0.0",
-    "nyc": "^14.0.0",
+    "nyc": "^15.0.0",
     "shell-escape": "^0.2.0",
     "shelljs": "^0.8.3",
     "spec-xunit-file": "0.0.1-3"


### PR DESCRIPTION
Updated two packages for resolving the vulnerability

### nyc 
nyc updatd from v14.1.1 to v15.0.0 for resolving handlebars vulnerability

## mocha
mocha updated from v6.0.0 to v7.0.0 for resolving minimist vulnerability