### PR TITLE
Update mocha to version 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jenkins-mocha",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Bin wrapper for Mocha + Nyc + Xunit (for Jenkins)",
   "bin": {
     "jenkins-mocha": "./bin/jenkins.js"
@@ -26,7 +26,7 @@
   "bugs": "https://github.com/stjohnjohnson/jenkins-mocha/issues",
   "license": "MIT",
   "dependencies": {
-    "mocha": "^6.0.0",
+    "mocha": "^7.0.0",
     "npm-which": "^3.0.0",
     "nyc": "^14.0.0",
     "shell-escape": "^0.2.0",


### PR DESCRIPTION
Fixes minimist security vulnerability and updates mocha to 7.

This is related to the [comment here](https://github.com/stjohnjohnson/jenkins-mocha/pull/43#issuecomment-643060091)