### PR TITLE
add engines.node field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "mockery": "^2.0.0",
     "sinon": "^7.0.0"
   },
+  "engines": {
+    "node": "12.x || 14.x || >= 16.x"
+  },
   "release": {
     "debug": false,
     "verifyConditions": {


### PR DESCRIPTION
It helps users a lot to be able to see supported engine versions in the package registry.

This sets minimum Node.js version to v12. Motivation:
- Currently published version breaks on Nodejs version lower than v10 so there is an already undocumented minimum version of v10.
  - v10 is ancient by now (EoL since 2021-04-30) so I think silently dropping support for it is OK
  - v12 is also EoL as of 2022-04-30. However, it's still the default version in repos for current LTS versions of Debian/Ubuntu and is still widely deployed.
